### PR TITLE
ready for publishing to npm (0.0.5)

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -42,7 +42,7 @@ inline uint32 Uint64Low32(const uint64 &x) {
 }
 
 inline uint64 HighLow32ToUint64(const uint32 &low, const uint32 &high) {
-    return ((uint64_t)low) + ((((uint64_t)high) << 32) & 0xFFFFFFFF00000000);
+    return ((uint64_t)low) + ((((uint64_t)high) << 32) & 0xFFFFFFFF00000000ll);
 }
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cityhash",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "main": "./build/Release/cityhash",
   "description": "NodeJS binding for Google CityHash.",
   "dependencies": [ ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cityhash",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "main": "./build/Release/cityhash",
   "description": "NodeJS binding for Google CityHash.",
   "dependencies": [ ],


### PR DESCRIPTION
Without this fix, redhat/x64 will throw an error '`long' is two large for constant variable.`
