### PR TITLE
Cityhash 1.1.0

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -41,6 +41,13 @@ npm install cityhash
     function stringify(obj);
 
     /**
+     * Compute hash for str by CityHash32().
+     * @param {string | Buffer} str The string to compute hash.
+     * @return {hash} 32-bit hash value.
+    **/
+    function hash32(str);
+
+    /**
      * Compute hash for str by CityHash64().
      * @param {string} str The string to compute hash.
      * @param {unsigned long long | string | 64-bit hash object} [seed0] The hash seed.

--- a/binding.cc
+++ b/binding.cc
@@ -147,6 +147,17 @@ stringify_hash(Local<Object> obj) {
 }
 
 Local<Object>
+objectify_hash(const uint32 &hash) {
+    Local<Object> ret = Object::New();
+    ret->Set(String::New("low"), Integer::NewFromUnsigned(hash));
+    ret->Set(String::New("high"), Integer::NewFromUnsigned(0));
+    ret->Set(String::New("value"), stringify_hash(hash));
+    ret->Set(String::New("uint64"), Boolean::New(false));
+
+    return ret;
+}
+
+Local<Object>
 objectify_hash(const uint64 &hash) {
     uint32 low = Uint64Low32(hash);
     uint32 high = Uint64High32(hash);

--- a/binding.cc
+++ b/binding.cc
@@ -225,6 +225,30 @@ node_Objectify(const Arguments& args) {
 }
 
 Handle<Value>
+node_CityHash32(const Arguments& args) {
+    HandleScope scope;
+
+    int args_len = args.Length();
+    if(args_len == 0 || args_len > 1) {
+        return ThrowException(String::New("Invalid arguments."));
+    }
+
+    String::Utf8Value data(args[0]->ToString());
+    const char* str = *data;
+    size_t len = data.length();
+
+    if (Buffer::HasInstance(args[0])) {
+      Local<Object> obj = args[0]->ToObject();
+      str = Buffer::Data(obj);
+      len = Buffer::Length(obj);
+    }
+
+    uint32 hash = CityHash32(str, len);
+
+    return scope.Close(objectify_hash(hash));
+}
+
+Handle<Value>
 node_CityHash64(const Arguments& args) {
     HandleScope scope;
 
@@ -386,6 +410,7 @@ init (Handle<Object> target) {
     HandleScope scope;
     target->Set(String::New("stringify"), FunctionTemplate::New(node_Stringify)->GetFunction());
     target->Set(String::New("objectify"), FunctionTemplate::New(node_Objectify)->GetFunction());
+    target->Set(String::New("hash32"), FunctionTemplate::New(node_CityHash32)->GetFunction());
     target->Set(String::New("hash64"), FunctionTemplate::New(node_CityHash64)->GetFunction());
     target->Set(String::New("hash128"), FunctionTemplate::New(node_CityHash128)->GetFunction());
     target->Set(String::New("crc128"), FunctionTemplate::New(node_CityHashCrc128)->GetFunction());

--- a/cityhash/city.cc
+++ b/cityhash/city.cc
@@ -46,32 +46,32 @@ static uint32 UNALIGNED_LOAD32(const char *p) {
   return result;
 }
 
-#if !defined(WORDS_BIGENDIAN)
-
-#define uint32_in_expected_order(x) (x)
-#define uint64_in_expected_order(x) (x)
-
-#else
-
 #ifdef _MSC_VER
+
 #include <stdlib.h>
 #define bswap_32(x) _byteswap_ulong(x)
 #define bswap_64(x) _byteswap_uint64(x)
 
 #elif defined(__APPLE__)
+
 // Mac OS X / Darwin features
 #include <libkern/OSByteOrder.h>
 #define bswap_32(x) OSSwapInt32(x)
 #define bswap_64(x) OSSwapInt64(x)
 
 #else
+
 #include <byteswap.h>
+
 #endif
 
+#ifdef WORDS_BIGENDIAN
 #define uint32_in_expected_order(x) (bswap_32(x))
 #define uint64_in_expected_order(x) (bswap_64(x))
-
-#endif  // WORDS_BIGENDIAN
+#else
+#define uint32_in_expected_order(x) (x)
+#define uint64_in_expected_order(x) (x)
+#endif
 
 #if !defined(LIKELY)
 #if HAVE_BUILTIN_EXPECT
@@ -93,20 +93,144 @@ static uint32 Fetch32(const char *p) {
 static const uint64 k0 = 0xc3a5c85c97cb3127ULL;
 static const uint64 k1 = 0xb492b66fbe98f273ULL;
 static const uint64 k2 = 0x9ae16a3b2f90404fULL;
-static const uint64 k3 = 0xc949d7c7509e6557ULL;
+
+// Magic numbers for 32-bit hashing.  Copied from Murmur3.
+static const uint32_t c1 = 0xcc9e2d51;
+static const uint32_t c2 = 0x1b873593;
+
+// A 32-bit to 32-bit integer hash copied from Murmur3.
+static uint32 fmix(uint32 h)
+{
+  h ^= h >> 16;
+  h *= 0x85ebca6b;
+  h ^= h >> 13;
+  h *= 0xc2b2ae35;
+  h ^= h >> 16;
+  return h;
+}
+
+static uint32 Rotate32(uint32 val, int shift) {
+  // Avoid shifting by 32: doing so yields an undefined result.
+  return shift == 0 ? val : ((val >> shift) | (val << (32 - shift)));
+}
+
+#undef PERMUTE3
+#define PERMUTE3(a, b, c) do { std::swap(a, b); std::swap(a, c); } while (0)
+
+static uint32 Mur(uint32 a, uint32 h) {
+  // Helper from Murmur3 for combining two 32-bit values.
+  a *= c1;
+  a = Rotate32(a, 17);
+  a *= c2;
+  h ^= a;
+  h = Rotate32(h, 19);
+  return h * 5 + 0xe6546b64;
+}
+
+static uint32 Hash32Len13to24(const char *s, size_t len) {
+  uint32 a = Fetch32(s - 4 + (len >> 1));
+  uint32 b = Fetch32(s + 4);
+  uint32 c = Fetch32(s + len - 8);
+  uint32 d = Fetch32(s + (len >> 1));
+  uint32 e = Fetch32(s);
+  uint32 f = Fetch32(s + len - 4);
+  uint32 h = len;
+
+  return fmix(Mur(f, Mur(e, Mur(d, Mur(c, Mur(b, Mur(a, h)))))));
+}
+
+static uint32 Hash32Len0to4(const char *s, size_t len) {
+  uint32 b = 0;
+  uint32 c = 9;
+  for (int i = 0; i < len; i++) {
+    b = b * c1 + s[i];
+    c ^= b;
+  }
+  return fmix(Mur(b, Mur(len, c)));
+}
+
+static uint32 Hash32Len5to12(const char *s, size_t len) {
+  uint32 a = len, b = len * 5, c = 9, d = b;
+  a += Fetch32(s);
+  b += Fetch32(s + len - 4);
+  c += Fetch32(s + ((len >> 1) & 4));
+  return fmix(Mur(c, Mur(b, Mur(a, d))));
+}
+
+uint32 CityHash32(const char *s, size_t len) {
+  if (len <= 24) {
+    return len <= 12 ?
+        (len <= 4 ? Hash32Len0to4(s, len) : Hash32Len5to12(s, len)) :
+        Hash32Len13to24(s, len);
+  }
+
+  // len > 24
+  uint32 h = len, g = c1 * len, f = g;
+  uint32 a0 = Rotate32(Fetch32(s + len - 4) * c1, 17) * c2;
+  uint32 a1 = Rotate32(Fetch32(s + len - 8) * c1, 17) * c2;
+  uint32 a2 = Rotate32(Fetch32(s + len - 16) * c1, 17) * c2;
+  uint32 a3 = Rotate32(Fetch32(s + len - 12) * c1, 17) * c2;
+  uint32 a4 = Rotate32(Fetch32(s + len - 20) * c1, 17) * c2;
+  h ^= a0;
+  h = Rotate32(h, 19);
+  h = h * 5 + 0xe6546b64;
+  h ^= a2;
+  h = Rotate32(h, 19);
+  h = h * 5 + 0xe6546b64;
+  g ^= a1;
+  g = Rotate32(g, 19);
+  g = g * 5 + 0xe6546b64;
+  g ^= a3;
+  g = Rotate32(g, 19);
+  g = g * 5 + 0xe6546b64;
+  f += a4;
+  f = Rotate32(f, 19);
+  f = f * 5 + 0xe6546b64;
+  size_t iters = (len - 1) / 20;
+  do {
+    uint32 a0 = Rotate32(Fetch32(s) * c1, 17) * c2;
+    uint32 a1 = Fetch32(s + 4);
+    uint32 a2 = Rotate32(Fetch32(s + 8) * c1, 17) * c2;
+    uint32 a3 = Rotate32(Fetch32(s + 12) * c1, 17) * c2;
+    uint32 a4 = Fetch32(s + 16);
+    h ^= a0;
+    h = Rotate32(h, 18);
+    h = h * 5 + 0xe6546b64;
+    f += a1;
+    f = Rotate32(f, 19);
+    f = f * c1;
+    g += a2;
+    g = Rotate32(g, 18);
+    g = g * 5 + 0xe6546b64;
+    h ^= a3 + a1;
+    h = Rotate32(h, 19);
+    h = h * 5 + 0xe6546b64;
+    g ^= a4;
+    g = bswap_32(g) * 5;
+    h += a4 * 5;
+    h = bswap_32(h);
+    f += a0;
+    PERMUTE3(f, h, g);
+    s += 20;
+  } while (--iters != 0);
+  g = Rotate32(g, 11) * c1;
+  g = Rotate32(g, 17) * c1;
+  f = Rotate32(f, 11) * c1;
+  f = Rotate32(f, 17) * c1;
+  h = Rotate32(h + g, 19);
+  h = h * 5 + 0xe6546b64;
+  h = Rotate32(h, 17) * c1;
+  h = Rotate32(h + f, 19);
+  h = h * 5 + 0xe6546b64;
+  h = Rotate32(h, 17) * c1;
+  return h;
+}
 
 // Bitwise right rotate.  Normally this will compile to a single
 // instruction, especially if the shift is a manifest constant.
 static uint64 Rotate(uint64 val, int shift) {
   // Avoid shifting by 64: doing so yields an undefined result.
   return shift == 0 ? val : ((val >> shift) | (val << (64 - shift)));
-}
-
-// Equivalent to Rotate(), but requires the second arg to be non-zero.
-// On x86-64, and probably others, it's possible for this to compile
-// to a single instruction if both args are already in registers.
-static uint64 RotateByAtLeast1(uint64 val, int shift) {
-  return (val >> shift) | (val << (64 - shift));
 }
 
 static uint64 ShiftMix(uint64 val) {
@@ -117,15 +241,29 @@ static uint64 HashLen16(uint64 u, uint64 v) {
   return Hash128to64(uint128(u, v));
 }
 
+static uint64 HashLen16(uint64 u, uint64 v, uint64 mul) {
+  // Murmur-inspired hashing.
+  uint64 a = (u ^ v) * mul;
+  a ^= (a >> 47);
+  uint64 b = (v ^ a) * mul;
+  b ^= (b >> 47);
+  b *= mul;
+  return b;
+}
+
 static uint64 HashLen0to16(const char *s, size_t len) {
-  if (len > 8) {
-    uint64 a = Fetch64(s);
+  if (len >= 8) {
+    uint64 mul = k2 + len * 2;
+    uint64 a = Fetch64(s) + k2;
     uint64 b = Fetch64(s + len - 8);
-    return HashLen16(a, RotateByAtLeast1(b + len, len)) ^ b;
+    uint64 c = Rotate(b, 37) * mul + a;
+    uint64 d = (Rotate(a, 25) + b) * mul;
+    return HashLen16(c, d, mul);
   }
   if (len >= 4) {
+    uint64 mul = k2 + len * 2;
     uint64 a = Fetch32(s);
-    return HashLen16(len + (a << 3), Fetch32(s + len - 4));
+    return HashLen16(len + (a << 3), Fetch32(s + len - 4), mul);
   }
   if (len > 0) {
     uint8 a = s[0];
@@ -133,7 +271,7 @@ static uint64 HashLen0to16(const char *s, size_t len) {
     uint8 c = s[len - 1];
     uint32 y = static_cast<uint32>(a) + (static_cast<uint32>(b) << 8);
     uint32 z = len + (static_cast<uint32>(c) << 2);
-    return ShiftMix(y * k2 ^ z * k3) * k2;
+    return ShiftMix(y * k2 ^ z * k0) * k2;
   }
   return k2;
 }
@@ -141,12 +279,13 @@ static uint64 HashLen0to16(const char *s, size_t len) {
 // This probably works well for 16-byte strings as well, but it may be overkill
 // in that case.
 static uint64 HashLen17to32(const char *s, size_t len) {
+  uint64 mul = k2 + len * 2;
   uint64 a = Fetch64(s) * k1;
   uint64 b = Fetch64(s + 8);
-  uint64 c = Fetch64(s + len - 8) * k2;
-  uint64 d = Fetch64(s + len - 16) * k0;
-  return HashLen16(Rotate(a - b, 43) + Rotate(c, 30) + d,
-                   a + Rotate(b ^ k3, 20) - c + len);
+  uint64 c = Fetch64(s + len - 8) * mul;
+  uint64 d = Fetch64(s + len - 16) * k2;
+  return HashLen16(Rotate(a + b, 43) + Rotate(c, 30) + d,
+                   a + Rotate(b + k2, 18) + c, mul);
 }
 
 // Return a 16-byte hash for 48 bytes.  Quick and dirty.
@@ -175,26 +314,24 @@ static pair<uint64, uint64> WeakHashLen32WithSeeds(
 
 // Return an 8-byte hash for 33 to 64 bytes.
 static uint64 HashLen33to64(const char *s, size_t len) {
-  uint64 z = Fetch64(s + 24);
-  uint64 a = Fetch64(s) + (len + Fetch64(s + len - 16)) * k0;
-  uint64 b = Rotate(a + z, 52);
-  uint64 c = Rotate(a, 37);
-  a += Fetch64(s + 8);
-  c += Rotate(a, 7);
-  a += Fetch64(s + 16);
-  uint64 vf = a + z;
-  uint64 vs = b + Rotate(a, 31) + c;
-  a = Fetch64(s + 16) + Fetch64(s + len - 32);
-  z = Fetch64(s + len - 8);
-  b = Rotate(a + z, 52);
-  c = Rotate(a, 37);
-  a += Fetch64(s + len - 24);
-  c += Rotate(a, 7);
-  a += Fetch64(s + len - 16);
-  uint64 wf = a + z;
-  uint64 ws = b + Rotate(a, 31) + c;
-  uint64 r = ShiftMix((vf + ws) * k2 + (wf + vs) * k0);
-  return ShiftMix(r * k0 + vs) * k2;
+  uint64 mul = k2 + len * 2;
+  uint64 a = Fetch64(s) * k2;
+  uint64 b = Fetch64(s + 8);
+  uint64 c = Fetch64(s + len - 24);
+  uint64 d = Fetch64(s + len - 32);
+  uint64 e = Fetch64(s + 16) * k2;
+  uint64 f = Fetch64(s + 24) * 9;
+  uint64 g = Fetch64(s + len - 8);
+  uint64 h = Fetch64(s + len - 16) * mul;
+  uint64 u = Rotate(a + g, 43) + (Rotate(b, 30) + c) * 9;
+  uint64 v = ((a + g) ^ d) + f + 1;
+  uint64 w = bswap_64((u + v) * mul) + h;
+  uint64 x = Rotate(e + f, 42) + c;
+  uint64 y = (bswap_64((v + w) * mul) + g) * mul;
+  uint64 z = e + f + c;
+  a = bswap_64((x + z) * mul + y) + b;
+  b = ShiftMix((z + a) * mul + d + h) * mul;
+  return b + x;
 }
 
 uint64 CityHash64(const char *s, size_t len) {
@@ -315,7 +452,10 @@ uint128 CityHash128WithSeed(const char *s, size_t len, uint128 seed) {
     len -= 128;
   } while (LIKELY(len >= 128));
   x += Rotate(v.first + z, 49) * k0;
-  z += Rotate(w.first, 37) * k0;
+  y = y * k0 + Rotate(w.second, 37);
+  z = z * k0 + Rotate(w.first, 27);
+  w.first *= 9;
+  v.first *= k0;
   // If 0 < len < 128, hash up to 4 chunks of 32 bytes each from the end of s.
   for (size_t tail_done = 0; tail_done < len; ) {
     tail_done += 32;
@@ -325,6 +465,7 @@ uint128 CityHash128WithSeed(const char *s, size_t len, uint128 seed) {
     z += w.second + Fetch64(s + len - tail_done);
     w.second += v.first;
     v = WeakHashLen32WithSeeds(s + len - tail_done, v.first + z, v.second);
+    v.first *= k0;
   }
   // At this point our 56 bytes of state should contain more than
   // enough information for a strong 128-bit hash.  We use two
@@ -336,19 +477,10 @@ uint128 CityHash128WithSeed(const char *s, size_t len, uint128 seed) {
 }
 
 uint128 CityHash128(const char *s, size_t len) {
-  if (len >= 16) {
-    return CityHash128WithSeed(s + 16,
-                               len - 16,
-                               uint128(Fetch64(s) ^ k3,
-                                       Fetch64(s + 8)));
-  } else if (len >= 8) {
-    return CityHash128WithSeed(NULL,
-                               0,
-                               uint128(Fetch64(s) ^ (len * k0),
-                                       Fetch64(s + len - 8) ^ k1));
-  } else {
-    return CityHash128WithSeed(s, len, uint128(k0, k1));
-  }
+  return len >= 16 ?
+      CityHash128WithSeed(s + 16, len - 16,
+                          uint128(Fetch64(s), Fetch64(s + 8) + k0)) :
+      CityHash128WithSeed(s, len, uint128(k0, k1));
 }
 
 #ifdef __SSE4_2__
@@ -363,60 +495,79 @@ static void CityHashCrc256Long(const char *s, size_t len,
   uint64 c = result[0] = HashLen16(b, len);
   uint64 d = result[1] = Fetch64(s + 120) * k0 + len;
   uint64 e = Fetch64(s + 184) + seed;
-  uint64 f = seed;
+  uint64 f = 0;
   uint64 g = 0;
-  uint64 h = 0;
-  uint64 i = 0;
-  uint64 j = 0;
-  uint64 t = c + d;
+  uint64 h = c + d;
+  uint64 x = seed;
+  uint64 y = 0;
+  uint64 z = 0;
 
   // 240 bytes of input per iter.
   size_t iters = len / 240;
   len -= iters * 240;
   do {
-#define CHUNK(multiplier, z)                                    \
-    {                                                           \
-      uint64 old_a = a;                                         \
-      a = Rotate(b, 41 ^ z) * multiplier + Fetch64(s);          \
-      b = Rotate(c, 27 ^ z) * multiplier + Fetch64(s + 8);      \
-      c = Rotate(d, 41 ^ z) * multiplier + Fetch64(s + 16);     \
-      d = Rotate(e, 33 ^ z) * multiplier + Fetch64(s + 24);     \
-      e = Rotate(t, 25 ^ z) * multiplier + Fetch64(s + 32);     \
-      t = old_a;                                                \
-    }                                                           \
-    f = _mm_crc32_u64(f, a);                                    \
-    g = _mm_crc32_u64(g, b);                                    \
-    h = _mm_crc32_u64(h, c);                                    \
-    i = _mm_crc32_u64(i, d);                                    \
-    j = _mm_crc32_u64(j, e);                                    \
+#undef CHUNK
+#define CHUNK(r)                                \
+    PERMUTE3(x, z, y);                          \
+    b += Fetch64(s);                            \
+    c += Fetch64(s + 8);                        \
+    d += Fetch64(s + 16);                       \
+    e += Fetch64(s + 24);                       \
+    f += Fetch64(s + 32);                       \
+    a += b;                                     \
+    h += f;                                     \
+    b += c;                                     \
+    f += d;                                     \
+    g += e;                                     \
+    e += z;                                     \
+    g += x;                                     \
+    z = _mm_crc32_u64(z, b + g);                \
+    y = _mm_crc32_u64(y, e + h);                \
+    x = _mm_crc32_u64(x, f + a);                \
+    e = Rotate(e, r);                           \
+    c += e;                                     \
     s += 40
 
-    CHUNK(1, 1); CHUNK(k0, 0);
-    CHUNK(1, 1); CHUNK(k0, 0);
-    CHUNK(1, 1); CHUNK(k0, 0);
+    CHUNK(0); PERMUTE3(a, h, c);
+    CHUNK(33); PERMUTE3(a, h, f);
+    CHUNK(0); PERMUTE3(b, h, f);
+    CHUNK(42); PERMUTE3(b, h, d);
+    CHUNK(0); PERMUTE3(b, h, e);
+    CHUNK(33); PERMUTE3(a, h, e);
   } while (--iters > 0);
 
   while (len >= 40) {
-    CHUNK(k0, 0);
+    CHUNK(29);
+    e ^= Rotate(a, 20);
+    h += Rotate(b, 30);
+    g ^= Rotate(c, 40);
+    f += Rotate(d, 34);
+    PERMUTE3(c, h, g);
     len -= 40;
   }
   if (len > 0) {
     s = s + len - 40;
-    CHUNK(k0, 0);
+    CHUNK(33);
+    e ^= Rotate(a, 43);
+    h += Rotate(b, 42);
+    g ^= Rotate(c, 41);
+    f += Rotate(d, 40);
   }
-  j += i << 32;
-  a = HashLen16(a, j);
-  h += g << 32;
-  b += h;
-  c = HashLen16(c, f) + i;
+  result[0] ^= h;
+  result[1] ^= g;
+  g += h;
+  a = HashLen16(a, g + z);
+  x += y << 32;
+  b += x;
+  c = HashLen16(c, z) + h;
   d = HashLen16(d, e + result[0]);
-  j += e;
-  i += HashLen16(h, t);
-  e = HashLen16(a, d) + j;
-  f = HashLen16(b, c) + a;
-  g = HashLen16(j, i) + c;
-  result[0] = e + f + g + h;
-  a = ShiftMix((a + g) * k0) * k0 + b;
+  g += e;
+  h += HashLen16(x, f);
+  e = HashLen16(a, d) + g;
+  z = HashLen16(b, c) + a;
+  y = HashLen16(g, h) + c;
+  result[0] = e + z + y + x;
+  a = ShiftMix((a + y) * k0) * k0 + b;
   result[1] += a + result[0];
   a = ShiftMix(a * k0) * k0 + c;
   result[2] = a + result[1];

--- a/cityhash/city.h
+++ b/cityhash/city.h
@@ -20,21 +20,36 @@
 //
 // CityHash, by Geoff Pike and Jyrki Alakuijala
 //
-// This file provides a few functions for hashing strings. On x86-64
-// hardware in 2011, CityHash64() is faster than other high-quality
-// hash functions, such as Murmur.  This is largely due to higher
-// instruction-level parallelism.  CityHash64() and CityHash128() also perform
-// well on hash-quality tests.
+// http://code.google.com/p/cityhash/
 //
-// CityHash128() is optimized for relatively long strings and returns
-// a 128-bit hash.  For strings more than about 2000 bytes it can be
-// faster than CityHash64().
+// This file provides a few functions for hashing strings.  All of them are
+// high-quality functions in the sense that they pass standard tests such
+// as Austin Appleby's SMHasher.  They are also fast.
+//
+// For 64-bit x86 code, on short strings, we don't know of anything faster than
+// CityHash64 that is of comparable quality.  We believe our nearest competitor
+// is Murmur3.  For 64-bit x86 code, CityHash64 is an excellent choice for hash
+// tables and most other hashing (excluding cryptography).
+//
+// For 64-bit x86 code, on long strings, the picture is more complicated.
+// On many recent Intel CPUs, such as Nehalem, Westmere, Sandy Bridge, etc.,
+// CityHashCrc128 appears to be faster than all competitors of comparable
+// quality.  CityHash128 is also good but not quite as fast.  We believe our
+// nearest competitor is Bob Jenkins' Spooky.  We don't have great data for
+// other 64-bit CPUs, but for long strings we know that Spooky is slightly
+// faster than CityHash on some relatively recent AMD x86-64 CPUs, for example.
+//
+// For 32-bit x86 code, we don't know of anything faster than CityHash32 that
+// is of comparable quality.  We believe our nearest competitor is Murmur3A.
+// (On 64-bit CPUs, it is typically faster to use the other CityHash variants.)
 //
 // Functions in the CityHash family are not suitable for cryptography.
 //
-// WARNING: This code has not been tested on big-endian platforms!
+// WARNING: This code has been only lightly tested on big-endian platforms!
 // It is known to work well on little-endian platforms that have a small penalty
 // for unaligned reads, such as current Intel and AMD moderate-to-high-end CPUs.
+// It should work on all 32-bit and 64-bit platforms that allow unaligned reads;
+// bug reports are welcome.
 //
 // By the way, for some hash functions, given strings a and b, the hash
 // of a+b is easily derived from the hashes of a and b.  This property
@@ -73,6 +88,9 @@ uint128 CityHash128(const char *s, size_t len);
 // Hash function for a byte array.  For convenience, a 128-bit seed is also
 // hashed into the result.
 uint128 CityHash128WithSeed(const char *s, size_t len, uint128 seed);
+
+// Hash function for a byte array.  Most useful in 32-bit binaries.
+uint32 CityHash32(const char *buf, size_t len);
 
 // Hash 128 input bits down to 64 bits of output.
 // This is intended to be a reasonably good hash function.

--- a/test.js
+++ b/test.js
@@ -32,7 +32,9 @@ function assertEqual(expected, actual, message) {
             message = '';
         }
         passed = false;
-        console.log('[Error]' + message + 'Expected ' + JSON.stringify(expected) + ' , but actual is ' + JSON.stringify(actual));
+        console.log('[Error]' + message +
+                    'Expected ' + JSON.stringify(expected, null, 4) +
+                    ' , but actual is ' + JSON.stringify(actual, null, 4));
     } else {
         console.log('[PASS] ' + message);
     }
@@ -68,178 +70,200 @@ assertEqual({
             }}, cityhash.objectify('9138004313465017137,12242971252332641544'), 'Stringify for uint128 object');
 
 assertEqual({
-  "low": 2999840452,
-  "high": 0,
-  "value": "2999840452",
-  "uint64": false
-  }, cityhash.hash32('Hello'), "Hash32 for 'Hello'");
+      "low": 2999840452,
+      "high": 0,
+      "value": "2999840452",
+      "uint64": false
+    }, cityhash.hash32('Hello'), "Hash32 for 'Hello'");
 
 assertEqual({
-    low: 1727229466,
-    high: 1535838579,
-    uint64: true,
-    value:'6596376470467341850'
+      "low": 845881479,
+      "high": 3586685982,
+      "value": "15404698994557526151",
+      "uint64": true
     }, cityhash.hash64('Hello'), 'Hash64 for "Hello"');
 
 assertEqual({
-        low: 4079208671,
-        high: 600288677,
-        uint64: true,
-        value: '2578220239953316063'
+      "low": 825756904,
+      "high": 3029067177,
+      "value": "13009744463427800296",
+      "uint64": true
     }, cityhash.hash64('hello'), 'Hash64 for "hello"');
 
 assertEqual({
-        low: 2569634289,
-        high: 3664379964,
-        uint64: true,
-        value: '15738392108067291633'
+      "low": 3137522328,
+      "high": 3490861664,
+      "value": "14993136684877662872",
+      "uint64": true
     }, cityhash.hash64('Hello', 87392039), 'Hash64 for "hello" with seed 87392039');
 
 var b = new Buffer(4)
 b.writeUInt32LE(7771789, 0)
 assertEqual({
-    low: 3883967176,
-    high: 3780832496,
-    uint64: true,
-    value:'16238551925858017992'
+      "low": 1072348245,
+      "high": 3201827915,
+      "value": "13751746183417216085",
+      "uint64": true
     }, cityhash.hash64(b, "2310915232984335893"), 'Hash64 for Buffer');
 
-assertEqual({
-        low: 2569634289,
-        high: 3664379964,
-        uint64: true,
-        value: '15738392108067291633'
+  assertEqual({
+      "low": 3137522328,
+      "high": 3490861664,
+      "value": "14993136684877662872",
+      "uint64": true
     }, cityhash.hash64('Hello', cityhash.objectify(87392039)), 'Hash64 for "hello" with objectify seed 87392039');
 
 assertEqual({
-        low: 2389520903,
-        high: 3787608545,
-        value: '16267654833214665223',
-        uint64: true,
+      "low": 4137286146,
+      "high": 1829140166,
+      "value": "7856097196907297282",
+      "uint64": true
     }, cityhash.hash64('Hello', 87392039, 1230234), 'Hash64 for "hello" with seed 87392039 and 1230234');
 
 assertEqual({
         "low": {
-            "low": 68277041,
-            "high": 2127607426,
-            "value": "9138004313465017137",
+            "low": 1746744350,
+            "high": 270899971,
+            "value": "1163506517679092766",
             "uint64": true
         },
         "high": {
-            "low": 3936042248,
-            "high": 2850538876,
-            "value": "12242971252332641544",
+            "low": 1430058029,
+            "high": 2521510841,
+            "value": "10829806600034513965",
             "uint64": true
         },
-        "value": "9138004313465017137,12242971252332641544",
+        "value": "1163506517679092766,10829806600034513965",
         "uint128": true
     }, cityhash.hash128('Hello'), 'Hash128 for "Hello"');
 
 assertEqual({
         "low": {
-            "low": 3440602095,
-            "high": 3148776037,
-            "value": "13523890104784088047",
+            "low": 3029444426,
+            "high": 1869800619,
+            "value": "8030732511675000650",
             "uint64": true
         },
         "high": {
-            "low": 2750723564,
-            "high": 4052229467,
-            "value": "17404193039403234796",
+            "low": 189133639,
+            "high": 1695846232,
+            "value": "7283604105673962311",
             "uint64": true
         },
-        "value": "13523890104784088047,17404193039403234796",
+        "value": "8030732511675000650,7283604105673962311",
         "uint128": true
     }, cityhash.hash128('hello'), 'Hash128 for "hello"');
 
 assertEqual({
         "low": {
-            "low": 3184066266,
-            "high": 3674042232,
-            "value": "15779891233746910938",
+            "low": 2988849008,
+            "high": 3870103733,
+            "value": "16621968968351364976",
             "uint64": true
         },
         "high": {
-            "low": 4196783977,
-            "high": 3519958761,
-            "value": "15118107765960464233",
+            "low": 71986147,
+            "high": 2418007629,
+            "value": "10385263688105487331",
             "uint64": true
         },
-        "value": "15779891233746910938,15118107765960464233",
+        "value": "16621968968351364976,10385263688105487331",
         "uint128": true
     }, cityhash.hash128('Hello', '12343,30293'), 'Hash128 for "Hello" with seed 12343,30293');
 
 assertEqual({
         "low": {
-            "low": 3184066266,
-            "high": 3674042232,
-            "value": "15779891233746910938",
+            "low": 2988849008,
+            "high": 3870103733,
+            "value": "16621968968351364976",
             "uint64": true
         },
         "high": {
-            "low": 4196783977,
-            "high": 3519958761,
-            "value": "15118107765960464233",
+            "low": 71986147,
+            "high": 2418007629,
+            "value": "10385263688105487331",
             "uint64": true
         },
-        "value": "15779891233746910938,15118107765960464233",
+        "value": "16621968968351364976,10385263688105487331",
         "uint128": true
     }, cityhash.hash128('Hello', cityhash.objectify('12343,30293')), 'Hash128 for "Hello" with objectify seed 12343,30293');
 
 if (cityhash.isCrcSupported()) {
   assertEqual({
           "low": {
-              "low": 68277041,
-              "high": 2127607426,
-              "value": "9138004313465017137",
+              "low": 1746744350,
+              "high": 270899971,
+              "value": "1163506517679092766",
               "uint64": true
           },
           "high": {
-              "low": 3936042248,
-              "high": 2850538876,
-              "value": "12242971252332641544",
+              "low": 1430058029,
+              "high": 2521510841,
+              "value": "10829806600034513965",
               "uint64": true
           },
-          "value": "9138004313465017137,12242971252332641544",
+          "value": "1163506517679092766,10829806600034513965",
           "uint128": true
       }, cityhash.crc128('Hello'), 'Crc128 for "Hello"');
 
   assertEqual({
           "low": {
-              "low": 3184066266,
-              "high": 3674042232,
-              "value": "15779891233746910938",
+              "low": 2988849008,
+              "high": 3870103733,
+              "value": "16621968968351364976",
               "uint64": true
           },
           "high": {
-              "low": 4196783977,
-              "high": 3519958761,
-              "value": "15118107765960464233",
+              "low": 71986147,
+              "high": 2418007629,
+              "value": "10385263688105487331",
               "uint64": true
           },
-          "value": "15779891233746910938,15118107765960464233",
+          "value": "16621968968351364976,10385263688105487331",
           "uint128": true
       }, cityhash.crc128('Hello', '12343,30293'), 'Crc128 for "Hello" with seed 12343,30293');
 
   assertEqual({
           "low": {
-              "low": 3184066266,
-              "high": 3674042232,
-              "value": "15779891233746910938",
+              "low": 2988849008,
+              "high": 3870103733,
+              "value": "16621968968351364976",
               "uint64": true
           },
           "high": {
-              "low": 4196783977,
-              "high": 3519958761,
-              "value": "15118107765960464233",
+              "low": 71986147,
+              "high": 2418007629,
+              "value": "10385263688105487331",
               "uint64": true
           },
-          "value": "15779891233746910938,15118107765960464233",
+          "value": "16621968968351364976,10385263688105487331",
           "uint128": true
       }, cityhash.crc128('Hello', cityhash.objectify('12343,30293')), 'Crc128 for "Hello" with objectify seed 12343,30293');
 
-// since my computer does not support SSE4.2, can not calculate the CRC by CityHashCrc256 algorithm.
-// assertEqual({
-//     }, cityhash.crc256('Hello'), 'Crc256 for "Hello"');
+  assertEqual([
+      {
+          "low":1520785073,
+          "high":3649709413,
+          "value":"15675382570259142321",
+          "uint64":true
+      },
+      {
+          "low":3695378336,
+          "high":2185935084,
+          "value":"9388519700654391200",
+          "uint64":true
+      },
+      {
+          "low":2432607983,
+          "high":589289348,
+          "value":"2530978479973770991",
+          "uint64":true
+      },
+      {
+          "low":1486001901,
+          "high":2811866387,
+          "value":"12076874174372681453",
+          "uint64":true
+      }], cityhash.crc256('Hello'), 'Crc256 for "Hello"');
 }
 end();

--- a/test.js
+++ b/test.js
@@ -71,7 +71,7 @@ assertEqual({
   "low": 2999840452,
   "high": 0,
   "value": "2999840452",
-  "uint64":true
+  "uint64": false
   }, cityhash.hash32('Hello'), "Hash32 for 'Hello'");
 
 assertEqual({

--- a/test.js
+++ b/test.js
@@ -68,6 +68,13 @@ assertEqual({
             }}, cityhash.objectify('9138004313465017137,12242971252332641544'), 'Stringify for uint128 object');
 
 assertEqual({
+  "low": 2999840452,
+  "high": 0,
+  "value": "2999840452",
+  "uint64":true
+  }, cityhash.hash32('Hello'), "Hash32 for 'Hello'");
+
+assertEqual({
     low: 1727229466,
     high: 1535838579,
     uint64: true,


### PR DESCRIPTION
Updates CityHash to v1.1.0 from Google. Since v1.1.0 changes some of the hashing algorithms, I've updated all the tests as well.

Tested on OS X with clang 4.2 and GCC 4.2.1, with -msse4.2 and without.

As discussed in #7, this change is NOT backwards compatible due to changes in hashing, so a new release branch would probably be a good idea.
